### PR TITLE
Add ExitWithTimeout matcher

### DIFF
--- a/matchers/exit_with_timeout.go
+++ b/matchers/exit_with_timeout.go
@@ -1,0 +1,35 @@
+package cmdtest_matchers
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/vito/cmdtest"
+)
+
+func ExitWithTimeout(status int, timeout time.Duration) *ExitWithTimeoutMatcher {
+	return &ExitWithTimeoutMatcher{status, timeout}
+}
+
+type ExitWithTimeoutMatcher struct {
+	Status int
+	Timeout time.Duration
+}
+
+func (m *ExitWithTimeoutMatcher) Match(out interface{}) (bool, string, error) {
+	session, ok := out.(*cmdtest.Session)
+	if !ok {
+		return false, "", fmt.Errorf("Cannot expect exit status from %#v.", out)
+	}
+
+	status, err := session.Wait(m.Timeout)
+	if err != nil {
+		return false, err.Error(), nil
+	}
+
+	if status == m.Status {
+		return true, fmt.Sprintf("Expected to not exit with %#v", m.Status), nil
+	} else {
+		return false, fmt.Sprintf("Exited with status %d, expected %d", status, m.Status), nil
+	}
+}

--- a/matchers/exit_with_timeout_test.go
+++ b/matchers/exit_with_timeout_test.go
@@ -1,0 +1,22 @@
+package cmdtest_matchers_test
+
+import (
+	"time"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/vito/cmdtest/matchers"
+)
+
+var _ = Describe("ExitWithTimeout Matcher", func() {
+	It("matches if the program exits with the expected status within the specified timeout", func() {
+		Expect(Run("ls", "/that/is/one/unlikely/path")).To(ExitWithTimeout(1, 2*time.Second))
+	})
+
+	It("does not match if the program does not exit within the timeout", func() {
+		Expect(Run("bash", "-c", "sleep 2 && echo SUCCESS")).NotTo(ExitWithTimeout(0, 1*time.Second))
+	})
+
+	It("does not match if the program exits but without the expected status", func() {
+		Expect(Run("echo", "SUCCESS")).NotTo(ExitWithTimeout(1, 1*time.Second))
+	})
+})

--- a/matchers/say_with_timeout_test.go
+++ b/matchers/say_with_timeout_test.go
@@ -14,7 +14,7 @@ var _ = Describe("SayWithTimeout Matcher", func() {
 		Expect(Run("bash", "-c", "sleep 1 && echo hello")).To(SayWithTimeout("hello", 2*time.Second))
 	})
 
-	It("does not match if the program outputs does not output the expected string within the timeout", func() {
+	It("does not match if the program does not output the expected string within the timeout", func() {
 		Expect(Run("bash", "-c", "sleep 1 && echo hello")).NotTo(SayWithTimeout("hello", 500*time.Millisecond))
 	})
 })


### PR DESCRIPTION
Specify a timeout for longer-running commands.
